### PR TITLE
Update Mockito versions and configure Byte Buddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,20 +63,20 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.2.0</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.2.0</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
 		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-inline -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>5.2.0</version>
+                        <version>5.18.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>
@@ -109,6 +109,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.2.5</version>
+                                <configuration>
+                                        <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+                                </configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Summary
- update Mockito libraries to version 5.18.0
- configure maven-surefire-plugin to enable Byte Buddy on newer JDKs

## Testing
- `mvn test` *(fails: could not resolve parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ea4ca572483268bd39cae48ef4b93