### PR TITLE
Fix encoding in Messages.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.identicum.midpoint</groupId>
 	<artifactId>connector-koha</artifactId>
-	<version>1.0.0</version>
+        <version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>Midpoint Koha Connector</name>

--- a/src/main/resources/com/identicum/connectors/Messages.properties
+++ b/src/main/resources/com/identicum/connectors/Messages.properties
@@ -5,26 +5,26 @@
 # Nombre visible del conector en la UI
 connector.identicum.rest.display=Conector Koha para Usuarios (REST)
 
-# === 1. Configuración Base de la API ===
-serviceAddress.display=Dirección del servicio
+# === 1. Configuraci\u00f3n Base de la API ===
+serviceAddress.display=Direcci\u00f3n del servicio
 serviceAddress.help=URL base de la instancia de Koha. Ejemplo: http://koha.upeu.edu.pe. No incluir la ruta /api/v1. Es un campo obligatorio.
 
 rest.config.trustAllCertificates.display=Confiar en todos los certificados SSL
-rest.config.trustAllCertificates.help=Marcar solo para entornos de desarrollo. Si es 'true', el conector no validará los certificados SSL. En producción, debe ser 'false' para requerir un certificado SSL válido y confiable.
+rest.config.trustAllCertificates.help=Marcar solo para entornos de desarrollo. Si es 'true', el conector no validar\u00e1 los certificados SSL. En producci\u00f3n, debe ser 'false' para requerir un certificado SSL v\u00e1lido y confiable.
 
-# === 2. Estrategia de Autenticación ===
-authenticationMethodStrategy.display=Método de Autenticación
-authenticationMethodStrategy.help=Seleccione el método para conectarse a la API de Koha. Las opciones son 'BASIC' o 'OAUTH2'. Según la opción elegida, deberá completar los campos del grupo correspondiente.
+# === 2. Estrategia de Autenticaci\u00f3n ===
+authenticationMethodStrategy.display=M\u00e9todo de Autenticaci\u00f3n
+authenticationMethodStrategy.help=Seleccione el m\u00e9todo para conectarse a la API de Koha. Las opciones son 'BASIC' o 'OAUTH2'. Seg\u00fan la opci\u00f3n elegida, deber\u00e1 completar los campos del grupo correspondiente.
 
-username.display=Usuario (para Autenticación BASIC)
-username.help=Nombre de usuario de un cliente API de Koha con los permisos necesarios. Requerido si el método de autenticación es 'BASIC'.
+username.display=Usuario (para Autenticaci\u00f3n BASIC)
+username.help=Nombre de usuario de un cliente API de Koha con los permisos necesarios. Requerido si el m\u00e9todo de autenticaci\u00f3n es 'BASIC'.
 
-password.display=Contraseña (para Autenticación BASIC)
-password.help=Contraseña asociada al usuario para la autenticación 'BASIC'.
+password.display=Contrase\u00f1a (para Autenticaci\u00f3n BASIC)
+password.help=Contrase\u00f1a asociada al usuario para la autenticaci\u00f3n 'BASIC'.
 
-# === 4. Grupo de Autenticación OAuth2 ===
-koha.config.clientId.display=Client ID (para Autenticación OAUTH2)
-koha.config.clientId.help=El 'Client ID' generado en Koha para la autenticación OAuth2 (Client Credentials). Requerido si el método de autenticación es 'OAUTH2'.
+# === 4. Grupo de Autenticaci\u00f3n OAuth2 ===
+koha.config.clientId.display=Client ID (para Autenticaci\u00f3n OAUTH2)
+koha.config.clientId.help=El 'Client ID' generado en Koha para la autenticaci\u00f3n OAuth2 (Client Credentials). Requerido si el m\u00e9todo de autenticaci\u00f3n es 'OAUTH2'.
 
-koha.config.clientSecret.display=Client Secret (para Autenticación OAUTH2)
-koha.config.clientSecret.help=El 'Client Secret' asociado al Client ID para la autenticación 'OAUTH2'.
+koha.config.clientSecret.display=Client Secret (para Autenticaci\u00f3n OAUTH2)
+koha.config.clientSecret.help=El 'Client Secret' asociado al Client ID para la autenticaci\u00f3n 'OAUTH2'.

--- a/src/main/resources/midpoint/KohaResource.xml
+++ b/src/main/resources/midpoint/KohaResource.xml
@@ -20,7 +20,7 @@
             </q:equal>
             <q:equal>
                 <q:path>c:connectorVersion</q:path>
-                <q:value>1.0.0</q:value>
+                <q:value>1.0.1</q:value>
             </q:equal>
         </filter>
     </connectorRef>


### PR DESCRIPTION
## Summary
- convert Spanish text in Messages.properties to ASCII with Unicode escapes
- bump connector version from 1.0.0 to 1.0.1

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687eb6b296cc8326bc0d3f4458bc85ec