### PR TITLE
Refactor connector without abstract base

### DIFF
--- a/src/main/java/com/identicum/connectors/KohaAuthenticator.java
+++ b/src/main/java/com/identicum/connectors/KohaAuthenticator.java
@@ -16,7 +16,6 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
-import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
 import org.json.JSONException;
@@ -59,7 +58,7 @@ public class KohaAuthenticator {
     public CloseableHttpClient createAuthenticatedClient() {
         HttpRequestInterceptor authInterceptor;
         String authMethod = configuration.getAuthenticationMethodStrategy();
-        boolean useOAuth2 = StringUtil.isNotBlank(configuration.getClientId()) && configuration.getClientSecret() != null;
+        boolean useOAuth2 = StringUtil.isNotBlank(configuration.getClientId()) && StringUtil.isNotBlank(configuration.getClientSecret());
 
         if (useOAuth2 && !"BASIC".equalsIgnoreCase(authMethod)) {
             // Configurar interceptor para OAuth2
@@ -75,16 +74,14 @@ public class KohaAuthenticator {
             // Configurar interceptor para Basic Auth
             LOG.ok("AUTH: Configurando cliente HTTP para autenticación BASIC.");
             final String username = configuration.getUsername();
-            final GuardedString password = configuration.getPassword();
+            final String password = configuration.getPassword();
 
-            if (StringUtil.isBlank(username) || password == null) {
+            if (StringUtil.isBlank(username) || StringUtil.isBlank(password)) {
                 throw new ConfigurationException("El método de autenticación es BASIC pero el usuario/contraseña no están configurados.");
             }
 
             authInterceptor = (request, context) -> {
-                final StringBuilder passBuilder = new StringBuilder();
-                password.access(passBuilder::append);
-                String auth = username + ":" + passBuilder.toString();
+                String auth = username + ":" + password;
                 String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
                 request.setHeader("Authorization", "Basic " + encodedAuth);
             };
@@ -99,7 +96,7 @@ public class KohaAuthenticator {
         HttpClientBuilder builder = HttpClients.custom()
                 .addInterceptorLast(authInterceptor);
 
-        if (Boolean.TRUE.equals(configuration.getTrustAllCertificates())) {
+        if (configuration.isTrustAllCertificates()) {
             try {
                 TrustStrategy acceptingTrustStrategy = (chain, authType) -> true;
                 builder.setSSLContext(SSLContexts.custom()
@@ -139,13 +136,12 @@ public class KohaAuthenticator {
                 tokenRequest.setHeader("Content-Type", "application/x-www-form-urlencoded");
                 tokenRequest.setHeader("Accept", "application/json");
 
-                final StringBuilder secretBuilder = new StringBuilder();
-                configuration.getClientSecret().access(secretBuilder::append);
+                final String secret = configuration.getClientSecret();
 
                 List<NameValuePair> formParams = new ArrayList<>();
                 formParams.add(new BasicNameValuePair("grant_type", "client_credentials"));
                 formParams.add(new BasicNameValuePair("client_id", configuration.getClientId()));
-                formParams.add(new BasicNameValuePair("client_secret", secretBuilder.toString()));
+                formParams.add(new BasicNameValuePair("client_secret", secret));
 
                 tokenRequest.setEntity(new UrlEncodedFormEntity(formParams, StandardCharsets.UTF_8));
 

--- a/src/main/java/com/identicum/connectors/KohaConfiguration.java
+++ b/src/main/java/com/identicum/connectors/KohaConfiguration.java
@@ -1,19 +1,17 @@
 package com.identicum.connectors;
 
-import com.evolveum.polygon.rest.AbstractRestConfiguration;
-import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
+import java.util.Arrays;
+import java.util.List;
 
 /**
- * Configuración del conector Koha para MidPoint.
- * Esta clase define únicamente las propiedades necesarias para
- * el conector, organizadas en grupos lógicos para la UI.
+ * Configuración autocontenida y mínima para el conector Koha.
  */
-public class KohaConfiguration extends AbstractRestConfiguration {
+public class KohaConfiguration {
 
     // === 1. Configuración Base de la API ===
     private String serviceAddress;
-    private Boolean trustAllCertificates;
+    private boolean trustAllCertificates;
 
     @ConfigurationProperty(order = 10,
             displayMessageKey = "serviceAddress.display",
@@ -29,11 +27,11 @@ public class KohaConfiguration extends AbstractRestConfiguration {
     @ConfigurationProperty(order = 11,
             displayMessageKey = "rest.config.trustAllCertificates.display",
             helpMessageKey = "rest.config.trustAllCertificates.help")
-    public Boolean getTrustAllCertificates() {
+    public boolean isTrustAllCertificates() {
         return trustAllCertificates;
     }
 
-    public void setTrustAllCertificates(Boolean trustAllCertificates) {
+    public void setTrustAllCertificates(boolean trustAllCertificates) {
         this.trustAllCertificates = trustAllCertificates;
     }
 
@@ -53,7 +51,7 @@ public class KohaConfiguration extends AbstractRestConfiguration {
 
     // === 3. Autenticación BASIC ===
     private String username;
-    private GuardedString password;
+    private String password;
 
     @ConfigurationProperty(order = 20,
             displayMessageKey = "username.display",
@@ -69,17 +67,17 @@ public class KohaConfiguration extends AbstractRestConfiguration {
     @ConfigurationProperty(order = 21, confidential = true,
             displayMessageKey = "password.display",
             helpMessageKey = "password.help")
-    public GuardedString getPassword() {
+    public String getPassword() {
         return password;
     }
 
-    public void setPassword(GuardedString password) {
+    public void setPassword(String password) {
         this.password = password;
     }
 
     // === 4. Autenticación OAuth2 (Client Credentials) ===
     private String clientId;
-    private GuardedString clientSecret;
+    private String clientSecret;
 
     @ConfigurationProperty(order = 30,
             displayMessageKey = "koha.config.clientId.display",
@@ -95,16 +93,15 @@ public class KohaConfiguration extends AbstractRestConfiguration {
     @ConfigurationProperty(order = 31, confidential = true,
             displayMessageKey = "koha.config.clientSecret.display",
             helpMessageKey = "koha.config.clientSecret.help")
-    public GuardedString getClientSecret() {
+    public String getClientSecret() {
         return clientSecret;
     }
 
-    public void setClientSecret(GuardedString clientSecret) {
+    public void setClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
     }
 
     // === 5. Validación de la configuración ===
-    @Override
     public void validate() {
         if (serviceAddress == null || serviceAddress.trim().isEmpty()) {
             throw new IllegalArgumentException("La dirección del servicio (serviceAddress) no puede estar vacía.");
@@ -113,5 +110,20 @@ public class KohaConfiguration extends AbstractRestConfiguration {
             throw new IllegalArgumentException("La estrategia de autenticación (authenticationMethodStrategy) es obligatoria.");
         }
         // Puedes agregar más validaciones si lo necesitas
+    }
+
+    /**
+     * Devuelve sólo los nombres de las propiedades locales, útil para la UI de MidPoint.
+     */
+    public static List<String> getLocalConfigurationProperties() {
+        return Arrays.asList(
+            "serviceAddress",
+            "trustAllCertificates",
+            "authenticationMethodStrategy",
+            "username",
+            "password",
+            "clientId",
+            "clientSecret"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- make `KohaConfiguration` self‑contained
- update `KohaAuthenticator` for new configuration API
- implement `KohaConnector` directly from `Connector`

## Testing
- `mvn test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6880451300988326911745e862038dde